### PR TITLE
Add tests for readcoda and compose functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 Manifest.toml
+test/data

--- a/Project.toml
+++ b/Project.toml
@@ -5,8 +5,10 @@ version = "0.3.0"
 
 [deps]
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
+DataDeps = "124859b0-ceae-595e-8997-d05f6a7a8dfe"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+RData = "df47a6cb-8c03-5eed-afd8-b6050d6c41da"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 UnicodePlots = "b8865327-cd53-5732-bb35-84acbb429228"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,9 @@
 using CoDa
 using Test
+using DataFrames
+using CSV
+using DataDeps
+using RData
 
 # list of maintainers
 maintainers = ["juliohm"]
@@ -8,6 +12,13 @@ maintainers = ["juliohm"]
 istravis = "TRAVIS" ∈ keys(ENV)
 ismaintainer = "USER" ∈ keys(ENV) && ENV["USER"] ∈ maintainers
 datadir = joinpath(@__DIR__,"data")
+mkpath(datadir)
+
+# download and setup data dependencies
+register(DataDep("juraset", "A geochemical dataset from the Swiss Jura",
+      "https://github.com/cran/compositions/raw/master/data/juraset.rda"))
+dataset = RData.load(joinpath(datadep"juraset", "juraset.rda"))
+CSV.write(joinpath(datadir,"juraset.csv"), dataset["juraset"])
 
 # list of tests
 testfiles = [

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -1,4 +1,26 @@
 @testset "Utils" begin
-  # TODO: readcoda
-  # TODO: compose
+  @testset "readcoda" begin
+    df = readcoda(joinpath(datadir,"juraset.csv"); codanames=(:Cd, :Cu, :Pb, :Co, :Cr, :Ni, :Zn));
+    @test names(df) == ["X", "Y", "Rock", "Land", "Cd|Cu|Pb|Co|Cr|Ni|Zn"]
+    @test size(df) == (359, 5)
+    @test df[1, "Cd|Cu|Pb|Co|Cr|Ni|Zn"] == Composition(Cd=1.74, Cu=25.72, Pb=77.36, Co=9.32, Cr=38.32, Ni=21.32, Zn=92.56)
+
+    df = readcoda(joinpath(datadir,"juraset.csv"); codanames=("Cd", "Cu", "Pb", "Co", "Cr", "Ni", "Zn"));
+    @test names(df) == ["X", "Y", "Rock", "Land", "Cd|Cu|Pb|Co|Cr|Ni|Zn"]
+    @test size(df) == (359, 5)
+    @test df[1, "Cd|Cu|Pb|Co|Cr|Ni|Zn"] == Composition(Cd=1.74, Cu=25.72, Pb=77.36, Co=9.32, Cr=38.32, Ni=21.32, Zn=92.56)
+  end
+
+  @testset "compose" begin
+    data = DataFrame!(CSV.File(joinpath(datadir,"juraset.csv")))
+    df = compose(data, (:Cd, :Cu, :Pb, :Co, :Cr, :Ni, :Zn))
+    @test names(df) == ["X", "Y", "Rock", "Land", "Cd|Cu|Pb|Co|Cr|Ni|Zn"]
+    @test size(df) == (359, 5)
+    @test df[1, "Cd|Cu|Pb|Co|Cr|Ni|Zn"] == Composition(Cd=1.74, Cu=25.72, Pb=77.36, Co=9.32, Cr=38.32, Ni=21.32, Zn=92.56)
+
+    df = compose(data, ("Cd", "Cu", "Pb", "Co", "Cr", "Ni", "Zn"))
+    @test names(df) == ["X", "Y", "Rock", "Land", "Cd|Cu|Pb|Co|Cr|Ni|Zn"]
+    @test size(df) == (359, 5)
+    @test df[1, "Cd|Cu|Pb|Co|Cr|Ni|Zn"] == Composition(Cd=1.74, Cu=25.72, Pb=77.36, Co=9.32, Cr=38.32, Ni=21.32, Zn=92.56)
+  end
 end


### PR DESCRIPTION
Addresses #10.
Adds the [jura dataset](https://rdrr.io/cran/compositions/man/jura.html) and test sets for functions `readcoda` and `compose`.
Slight modifications to `readcoda` and `compose` functions are introduced for compatibility with the `Vector{Symbol}` cols dispatch type. An additional dispatch method is introduced for `Array{String, 1}` cols.