### PR TITLE
Add tests for readcoda and compose functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 Manifest.toml
+test/data

--- a/Project.toml
+++ b/Project.toml
@@ -21,6 +21,8 @@ julia = "1"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+DataDeps = "124859b0-ceae-595e-8997-d05f6a7a8dfe"
+RData = "df47a6cb-8c03-5eed-afd8-b6050d6c41da"
 
 [targets]
-test = ["Test"]
+test = ["Test", "DataDeps", "RData"]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,9 @@
 using CoDa
 using Test
+using DataFrames
+using CSV
+using DataDeps
+using RData
 
 # list of maintainers
 maintainers = ["juliohm"]
@@ -7,7 +11,15 @@ maintainers = ["juliohm"]
 # environment settings
 istravis = "TRAVIS" ∈ keys(ENV)
 ismaintainer = "USER" ∈ keys(ENV) && ENV["USER"] ∈ maintainers
+ENV["DATADEPS_ALWAYS_ACCEPT"] = true
 datadir = joinpath(@__DIR__,"data")
+mkpath(datadir)
+
+# download and setup data dependencies
+register(DataDep("juraset", "A geochemical dataset from the Swiss Jura",
+      "https://github.com/cran/compositions/raw/master/data/juraset.rda"))
+dataset = RData.load(joinpath(datadep"juraset", "juraset.rda"))
+CSV.write(joinpath(datadir,"juraset.csv"), dataset["juraset"])
 
 # list of tests
 testfiles = [

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -1,4 +1,26 @@
 @testset "Utils" begin
-  # TODO: readcoda
-  # TODO: compose
+  @testset "readcoda" begin
+    df = readcoda(joinpath(datadir,"juraset.csv"); codanames=(:Cd, :Cu, :Pb, :Co, :Cr, :Ni, :Zn));
+    @test names(df) == ["X", "Y", "Rock", "Land", "Cd|Cu|Pb|Co|Cr|Ni|Zn"]
+    @test size(df) == (359, 5)
+    @test df[1, "Cd|Cu|Pb|Co|Cr|Ni|Zn"] == Composition(Cd=1.74, Cu=25.72, Pb=77.36, Co=9.32, Cr=38.32, Ni=21.32, Zn=92.56)
+
+    df = readcoda(joinpath(datadir,"juraset.csv"); codanames=("Cd", "Cu", "Pb", "Co", "Cr", "Ni", "Zn"));
+    @test names(df) == ["X", "Y", "Rock", "Land", "Cd|Cu|Pb|Co|Cr|Ni|Zn"]
+    @test size(df) == (359, 5)
+    @test df[1, "Cd|Cu|Pb|Co|Cr|Ni|Zn"] == Composition(Cd=1.74, Cu=25.72, Pb=77.36, Co=9.32, Cr=38.32, Ni=21.32, Zn=92.56)
+  end
+
+  @testset "compose" begin
+    data = DataFrame!(CSV.File(joinpath(datadir,"juraset.csv")))
+    df = compose(data, (:Cd, :Cu, :Pb, :Co, :Cr, :Ni, :Zn))
+    @test names(df) == ["X", "Y", "Rock", "Land", "Cd|Cu|Pb|Co|Cr|Ni|Zn"]
+    @test size(df) == (359, 5)
+    @test df[1, "Cd|Cu|Pb|Co|Cr|Ni|Zn"] == Composition(Cd=1.74, Cu=25.72, Pb=77.36, Co=9.32, Cr=38.32, Ni=21.32, Zn=92.56)
+
+    df = compose(data, ("Cd", "Cu", "Pb", "Co", "Cr", "Ni", "Zn"))
+    @test names(df) == ["X", "Y", "Rock", "Land", "Cd|Cu|Pb|Co|Cr|Ni|Zn"]
+    @test size(df) == (359, 5)
+    @test df[1, "Cd|Cu|Pb|Co|Cr|Ni|Zn"] == Composition(Cd=1.74, Cu=25.72, Pb=77.36, Co=9.32, Cr=38.32, Ni=21.32, Zn=92.56)
+  end
 end


### PR DESCRIPTION
Addresses #10.
Adds test sets for functions `readcoda` and `compose`.
Refactor of #11, which uses `DataDeps.jl` to avoid having to incorporate the jura dataset, to guarantee licensing requirements.