### PR TITLE
Refactor compose and readcoda's optional compositional column name arg

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -3,7 +3,8 @@
 # ------------------------------------------------------------------
 
 """
-    readcoda(args...; codanames=[], kwargs...)
+    readcoda(args...; codanames=(), kwargs...)
+    readcoda(args...; codanames=() => :coda, kwargs...)
 
 Read data from disk using `CSV.read`, optionally specifying
 the columns `codanames` with compositional data.
@@ -15,29 +16,36 @@ documentation for more details.
 This function returns a collection of [`Composition`](@ref)
 objects whose parts are the columns `codanames` in the file.
 """
-function readcoda(args...; codanames=[], kwargs...)
+function readcoda(args...; codanames=(), kwargs...)
   data = DataFrame!(CSV.File(args...; kwargs...))
-  cols = isempty(codanames) ? Tuple(propertynames(data)) : codanames
-  compose(data, cols)
+  if codanames isa NTuple || codanames isa AbstractArray
+    codanames = isempty(codanames) ? Tuple(propertynames(data)) => :coda : Tuple(Symbol.(codanames)) => :coda
+  end
+  compose(data, codanames)
 end
 
 """
     compose(data, cols)
+    compose(data, cols => :coda)
 
 Convert columns `cols` of tabular `data` into
 parts of a composition.
 """
-function compose(data, cols::NTuple{N,Symbol}) where {N}
+function compose(data, cols::Pair{NTuple{N,Symbol},Symbol}) where {N}
   # non-compositional columns
-  result = data[:,setdiff(propertynames(data), cols)]
+  result = data[:,setdiff(propertynames(data), cols.first)]
 
   # compositional columns
-  coda = map(eachrow(data[:,collect(cols)])) do row
+  coda = map(eachrow(data[:,collect(cols.first)])) do row
     Composition(Tuple(propertynames(row)), values(row))
   end
-  result[!, Symbol(join(cols, "|"))] = coda
+  result[!, cols.second] = coda
 
   result
 end
 
-compose(data, cols::NTuple{N,String}) where {N} = compose(data, Symbol.(cols))
+compose(data, cols::Pair{NTuple{N,String},Symbol}) where {N} = compose(data, Tuple(Symbol.(cols.first)) => cols.second)
+compose(data, cols::NTuple{N,Symbol}) where {N} = compose(data, cols => :coda)
+compose(data, cols::NTuple{N,String}) where {N} = compose(data, Symbol.(cols) => :coda)
+compose(data, cols::AbstractArray{Symbol,N}) where {N} = compose(data, Tuple(cols) => :coda)
+compose(data, cols::AbstractArray{String,N}) where {N} = compose(data, Tuple(Symbol.(cols)) => :coda)

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -1,26 +1,36 @@
 @testset "Utils" begin
   @testset "readcoda" begin
     df = readcoda(joinpath(datadir,"juraset.csv"); codanames=(:Cd, :Cu, :Pb, :Co, :Cr, :Ni, :Zn));
-    @test names(df) == ["X", "Y", "Rock", "Land", "Cd|Cu|Pb|Co|Cr|Ni|Zn"]
+    @test names(df) == ["X", "Y", "Rock", "Land", "coda"]
     @test size(df) == (359, 5)
-    @test df[1, "Cd|Cu|Pb|Co|Cr|Ni|Zn"] == Composition(Cd=1.74, Cu=25.72, Pb=77.36, Co=9.32, Cr=38.32, Ni=21.32, Zn=92.56)
+    @test df[1, "coda"] == Composition(Cd=1.74, Cu=25.72, Pb=77.36, Co=9.32, Cr=38.32, Ni=21.32, Zn=92.56)
 
     df = readcoda(joinpath(datadir,"juraset.csv"); codanames=("Cd", "Cu", "Pb", "Co", "Cr", "Ni", "Zn"));
-    @test names(df) == ["X", "Y", "Rock", "Land", "Cd|Cu|Pb|Co|Cr|Ni|Zn"]
+    @test names(df) == ["X", "Y", "Rock", "Land", "coda"]
     @test size(df) == (359, 5)
-    @test df[1, "Cd|Cu|Pb|Co|Cr|Ni|Zn"] == Composition(Cd=1.74, Cu=25.72, Pb=77.36, Co=9.32, Cr=38.32, Ni=21.32, Zn=92.56)
+    @test df[1, "coda"] == Composition(Cd=1.74, Cu=25.72, Pb=77.36, Co=9.32, Cr=38.32, Ni=21.32, Zn=92.56)
+
+    df = readcoda(joinpath(datadir,"juraset.csv"); codanames=(:Cd, :Cu, :Pb, :Co, :Cr, :Ni, :Zn) => :customcolname);
+    @test names(df) == ["X", "Y", "Rock", "Land", "customcolname"]
   end
 
   @testset "compose" begin
     data = DataFrame!(CSV.File(joinpath(datadir,"juraset.csv")))
     df = compose(data, (:Cd, :Cu, :Pb, :Co, :Cr, :Ni, :Zn))
-    @test names(df) == ["X", "Y", "Rock", "Land", "Cd|Cu|Pb|Co|Cr|Ni|Zn"]
+    @test names(df) == ["X", "Y", "Rock", "Land", "coda"]
     @test size(df) == (359, 5)
-    @test df[1, "Cd|Cu|Pb|Co|Cr|Ni|Zn"] == Composition(Cd=1.74, Cu=25.72, Pb=77.36, Co=9.32, Cr=38.32, Ni=21.32, Zn=92.56)
+    @test df[1, "coda"] == Composition(Cd=1.74, Cu=25.72, Pb=77.36, Co=9.32, Cr=38.32, Ni=21.32, Zn=92.56)
 
     df = compose(data, ("Cd", "Cu", "Pb", "Co", "Cr", "Ni", "Zn"))
-    @test names(df) == ["X", "Y", "Rock", "Land", "Cd|Cu|Pb|Co|Cr|Ni|Zn"]
+    @test names(df) == ["X", "Y", "Rock", "Land", "coda"]
     @test size(df) == (359, 5)
-    @test df[1, "Cd|Cu|Pb|Co|Cr|Ni|Zn"] == Composition(Cd=1.74, Cu=25.72, Pb=77.36, Co=9.32, Cr=38.32, Ni=21.32, Zn=92.56)
+    @test df[1, "coda"] == Composition(Cd=1.74, Cu=25.72, Pb=77.36, Co=9.32, Cr=38.32, Ni=21.32, Zn=92.56)
+
+    df = compose(data, (:Cd, :Cu, :Pb, :Co, :Cr, :Ni, :Zn) => :customcolname)
+    @test names(df) == ["X", "Y", "Rock", "Land", "customcolname"]
+
+    df = compose(data, ("Cd", "Cu", "Pb", "Co", "Cr", "Ni", "Zn") => :customcolname)
+    @test names(df) == ["X", "Y", "Rock", "Land", "customcolname"]
+
   end
 end


### PR DESCRIPTION
Addresses #13.
Changes default compositional column name to `:coda`.
A custom compositional column name may be set using a Pair{NTuple, Symbol}  (for example `; codanames=(colnames) => :customname`).
As a Julia newbie, I may be unfamiliar with conventions and best practices using julia `Pair` types and type checking; improvement suggestions are welcome!