### PR TITLE
Add elementary matrices constructors

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,6 +6,7 @@ version = "0.5.0"
 [deps]
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
+FillArrays = "1a297f60-69ca-5386-bcde-b61e274b549b"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"

--- a/src/CoDa.jl
+++ b/src/CoDa.jl
@@ -16,6 +16,7 @@ import Base: names, getproperty
 import LinearAlgebra: norm, dot, ⋅
 
 include("composition.jl")
+include("matrices.jl")
 include("transforms.jl")
 include("utils.jl")
 
@@ -25,6 +26,12 @@ export
   parts, components,
   norm, dot, ⋅,
   distance,
+
+  # matrices
+  JMatrix, J,
+  FMatrix, F,
+  GMatrix, G,
+  HMatrix, H,
 
   # transforms
   alr, alrinv,

--- a/src/matrices.jl
+++ b/src/matrices.jl
@@ -1,0 +1,59 @@
+# ------------------------------------------------------------------
+# Licensed under the MIT License. See LICENCE in the project root.
+# ------------------------------------------------------------------
+
+import Base: *, +
+import LinearAlgebra: Diagonal
+import FillArrays: Ones
+
+abstract type AbstractElementaryMatrix{T} end
+(*)(E::AbstractElementaryMatrix, A::AbstractArray) = E(size(A)[1]) * A
+(*)(A::AbstractArray, E::AbstractElementaryMatrix) = A * E(size(A)[2])
+(+)(E::AbstractElementaryMatrix, A::AbstractArray) = E(size(A)[1]) + A
+(+)(A::AbstractArray, E::AbstractElementaryMatrix) = E + A
+
+"""
+    JMatrix{T}
+
+Square matrix of ones.
+"""
+struct JMatrix{T} <: AbstractElementaryMatrix{T}
+end
+JMatrix{T}(d::Integer) where {T} = Ones{T}(d, d)
+(J::JMatrix{T})(d::Integer) where {T} = JMatrix{T}(d)
+const J = JMatrix{Bool}()
+
+"""
+    FMatrix{T}
+
+`F` matrix, as defined by Aitchison 1986.
+"""
+struct FMatrix{T} <: AbstractElementaryMatrix{T}
+end
+FMatrix{T}(d::Integer) where {T} = [Diagonal(fill(one(T), d)) -Ones{T}(d)]
+(F::FMatrix{T})(d::Integer) where {T} = FMatrix{T}(d)
+const F = FMatrix{Int}()
+# overwrite right side multiplication, since F ins't a square matrix
+(*)(F::FMatrix, A::AbstractArray) = F(size(A)[1]-1) * A
+
+"""
+    GMatrix{T}(N)
+
+`G` matrix, as defined by Aitchison 1986.
+"""
+struct GMatrix{T} <: AbstractElementaryMatrix{T}
+end
+GMatrix{T}(D::Integer) where {T} = -ones(T, D, D)/D + Diagonal(fill(one(T), D))
+(G::GMatrix{T})(D::Integer) where {T} = GMatrix{T}(D)
+const G = GMatrix{Float64}()
+
+"""
+    HMatrix{T}(d)
+
+`H` matrix, as defined by Aitchison 1986.
+"""
+struct HMatrix{T} <: AbstractElementaryMatrix{T}
+end
+HMatrix{T}(d::Integer) where {T} = ones(T, d, d) + Diagonal(fill(one(T), d))
+(H::HMatrix{T})(d::Integer) where {T} = HMatrix{T}(d)
+const H = HMatrix{Int}()

--- a/test/matrices.jl
+++ b/test/matrices.jl
@@ -1,0 +1,37 @@
+@testset "Matrices" begin
+  # tests with Aitchson's definitions
+  d = 10
+  D = d+1
+  @test J(d) == ones(d, d)
+  @test F(d) == [I(d) -ones(d)]
+  @test norm(G(D) - I(D)  + J(D)/ D, Inf) < 1e-5
+  @test H(d) == I(d) + J(d)
+
+  square_matrices = [J G H]
+
+  # tests of multiplications
+  for M in square_matrices
+    @test M(d) == M * I(d)
+    @test M(d) == I(d) * M
+    @test M(d) * collect(1:d) ==  M * collect(1:d)
+    @test collect(1:d)' * M(d) ==  collect(1:d)' * M
+  end
+
+  # tests of additions
+  for M in square_matrices
+    @test M(d) + M(d) == M + M(d)
+    @test M(d) + M(d) == M(d) + M
+    @test M(d) + I(d) == M + I(d)
+    @test I(d) + M(d) == I(d) + M
+  end
+
+  # tests of F (d x D)
+  @test F(d) == F * I(D)
+  @test F(d) == I(d) * F
+  @test F(d) * collect(1:D) ==  F * collect(1:D)
+  @test collect(1:d)' * F(d) ==  collect(1:d)' * F
+  @test F(d) + F(d) == F + F(d)
+  @test F(d) + F(d) == F(d) + F
+  @test F(d) + [I(d) ones(Int,d)] == F + [I(d) ones(Int,d)]
+  @test [I(d) ones(Int,d)] + F(d) == [I(d) ones(Int,d)] + F
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,6 +3,7 @@ using DataDeps
 using RData
 using CSV
 using Test
+using LinearAlgebra
 
 # accept downloads without interaction
 ENV["DATADEPS_ALWAYS_ACCEPT"] = true
@@ -26,6 +27,7 @@ CSV.write(joinpath(datadir,"jura.csv"), jura)
 # list of tests
 testfiles = [
   "compositions.jl",
+  "matrices.jl",
   "transforms.jl",
   "utils.jl"
 ]


### PR DESCRIPTION
As defined by Aitchison 1986.

A couple of observations regarding the choices of types:

1. Use `Integer` for `i` and `j`, following LinearAlgebra.jl conventions
2. Use `Int` for the variable inside the structure to avoid (re)allocation problems: it is used in `F` and `G` for the method `getindex`

The documentation was simplified to make it cleaner, but we can put the examples back.