### PR TITLE
Add elementary matrices constructors

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,6 +6,7 @@ version = "0.5.0"
 [deps]
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
+FillArrays = "1a297f60-69ca-5386-bcde-b61e274b549b"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"

--- a/src/CoDa.jl
+++ b/src/CoDa.jl
@@ -16,6 +16,7 @@ import Base: names, getproperty
 import LinearAlgebra: norm, dot, ⋅
 
 include("composition.jl")
+include("matrices.jl")
 include("transforms.jl")
 include("utils.jl")
 
@@ -25,6 +26,12 @@ export
   parts, components,
   norm, dot, ⋅,
   distance,
+
+  # matrices
+  JMatrix, J,
+  FMatrix, F,
+  GMatrix, G,
+  HMatrix, H,
 
   # transforms
   alr, alrinv,

--- a/src/CoDa.jl
+++ b/src/CoDa.jl
@@ -10,6 +10,8 @@ using DataFrames
 using StatsBase
 using StaticArrays
 using UnicodePlots
+using LinearAlgebra
+using FillArrays
 
 import Base: +, -, *, ==
 import Base: names, getproperty

--- a/src/matrices.jl
+++ b/src/matrices.jl
@@ -18,8 +18,8 @@ struct JMatrix{T} end
 `F` matrix, as defined by Aitchison 1986.
 """
 struct FMatrix{T} end
-(F::FMatrix{T})(d::Integer) where {T} = [Diagonal(fill(one(T), d)) -Ones{T}(d)]
-*(::FMatrix{T}, v::AbstractVector) where {T} = Fill(-last(v), length(v)-1) + v[1:end-1]
+(F::FMatrix{T})(d::Integer) where {T} = [I(d) -Ones{T}(d)]
+*(::FMatrix{T}, v::AbstractVector) where {T} = v[1:end-1] .- v[end]
 *(v::Adjoint{<:Any, <:AbstractVector}, ::FMatrix) = [v -sum(v)]
 
 """
@@ -28,8 +28,8 @@ struct FMatrix{T} end
 `G` matrix, as defined by Aitchison 1986.
 """
 struct GMatrix{T} end
-(G::GMatrix{T})(D::Integer) where {T} = -ones(T, D, D)/D + Diagonal(fill(one(T), D))
-*(::GMatrix, v::AbstractVector) = Fill(-sum(v)/length(v), length(v)) + v
+(G::GMatrix{T})(D::Integer) where {T} =  I(D) - (1/D) * J(D)
+*(::GMatrix, v::AbstractVector) = v .-sum(v)/length(v)
 *(v::Adjoint{<:Any, <:AbstractVector}, G::GMatrix) = (G*v')'
 
 """
@@ -38,8 +38,8 @@ struct GMatrix{T} end
 `H` matrix, as defined by Aitchison 1986.
 """
 struct HMatrix{T} end
-(H::HMatrix{T})(d::Integer) where {T} = ones(T, d, d) + Diagonal(fill(one(T), d))
-*(::HMatrix, v::AbstractVector) = Fill(sum(v), length(v)) + v
+(H::HMatrix{T})(d::Integer) where {T} = I(d) + J(d)
+*(::HMatrix, v::AbstractVector) = v .+ sum(v)
 *(v::Adjoint{<:Any, <:AbstractVector}, H::HMatrix) = (H*v')'
 
 """

--- a/src/matrices.jl
+++ b/src/matrices.jl
@@ -5,7 +5,7 @@
 """
     JMatrix{T}
 
-Square matrix of ones.
+Square matrix of ones. See also [`J`](@ref).
 """
 struct JMatrix{T} end
 (J::JMatrix{T})(d::Integer) where {T} = Ones{T}(d, d)
@@ -15,7 +15,7 @@ struct JMatrix{T} end
 """
     FMatrix{T}
 
-`F` matrix, as defined by Aitchison 1986.
+`F` matrix, as defined by Aitchison 1986. See also [`F`](@ref).
 """
 struct FMatrix{T} end
 (F::FMatrix{T})(d::Integer) where {T} = [I(d) -Ones{T}(d)]
@@ -23,9 +23,9 @@ struct FMatrix{T} end
 *(v::Adjoint{<:Any, <:AbstractVector}, ::FMatrix) = [v -sum(v)]
 
 """
-    GMatrix{T}(N)
+    GMatrix{T}
 
-`G` matrix, as defined by Aitchison 1986.
+`G` matrix, as defined by Aitchison 1986. See also [`G`](@ref).
 """
 struct GMatrix{T} end
 (G::GMatrix{T})(D::Integer) where {T} =  I(D) - (1/D) * J(D)
@@ -33,9 +33,9 @@ struct GMatrix{T} end
 *(v::Adjoint{<:Any, <:AbstractVector}, G::GMatrix) = (G*v')'
 
 """
-    HMatrix{T}(d)
+    HMatrix{T}
 
-`H` matrix, as defined by Aitchison 1986.
+`H` matrix, as defined by Aitchison 1986. See also [`H`](@ref).
 """
 struct HMatrix{T} end
 (H::HMatrix{T})(d::Integer) where {T} = I(d) + J(d)
@@ -46,7 +46,7 @@ struct HMatrix{T} end
     J
     J(d)
 
-User interface for JMatrix, the matrix of ones.
+User interface for [`JMatrix`](@ref), a `d` by `d` matrix of ones.
 
 ## Examples
 
@@ -62,7 +62,15 @@ const J = JMatrix{Bool}()
     F
     F(d)
 
-User interface for FMatrix, as defined by Aitchison.
+User interface for [`FMatrix`](@ref), as defined by Aitchison.
+
+`F` is a `d` by `D` matrix that can be defined as
+
+`F[i, j] = 1`, if `i==j`
+
+`F[i, j] = -1`, if `j==D`
+
+`F[i, j] = 0`, otherwise
 
 ## Examples
 
@@ -77,9 +85,13 @@ const F = FMatrix{Int}()
 
 """
     G
-    G(d)
+    G(N)
 
-User interface for GMatrix, as defined by Aitchison.
+User interface for [`GMatrix`](@ref), as defined by Aitchison.
+
+`G` is an `N` by `N` (usually with `N:=D`) matrix that can be defined as
+
+`G[i, j] = I[i, j] - J[i, j] / N`
 
 ## Examples
 
@@ -95,7 +107,11 @@ const G = GMatrix{Float64}()
     H
     H(d)
 
-User interface for HMatrix, as defined by Aitchison.
+User interface for [`HMatrix`](@ref), as defined by Aitchison.
+
+`H` is a `d` by `d` matrix that can be defined as
+
+`H[i, j] = I[i, j] + J[i, j]`
 
 ## Examples
 

--- a/src/matrices.jl
+++ b/src/matrices.jl
@@ -28,7 +28,7 @@ struct FMatrix{T} end
 `G` matrix, as defined by Aitchison 1986. See also [`G`](@ref).
 """
 struct GMatrix{T} end
-(G::GMatrix{T})(D::Integer) where {T} =  I(D) - (1/D) * J(D)
+(G::GMatrix{T})(D::Integer) where {T} = I(D) - (1/D) * J(D)
 *(::GMatrix, v::AbstractVector) = v .- sum(v) / length(v)
 *(v::Adjoint{<:Any, <:AbstractVector}, G::GMatrix) = (G*v')'
 

--- a/src/matrices.jl
+++ b/src/matrices.jl
@@ -9,7 +9,6 @@ Square matrix of ones.
 """
 struct JMatrix{T} end
 (J::JMatrix{T})(d::Integer) where {T} = Ones{T}(d, d)
-const J = JMatrix{Bool}()
 (*)(::JMatrix, v::AbstractVector) = Fill(sum(v), length(v))
 (*)(v::Adjoint{<:Any, <:AbstractVector}, J::JMatrix) = (J*v')'
 
@@ -20,7 +19,6 @@ const J = JMatrix{Bool}()
 """
 struct FMatrix{T} end
 (F::FMatrix{T})(d::Integer) where {T} = [Diagonal(fill(one(T), d)) -Ones{T}(d)]
-const F = FMatrix{Int}()
 (*)(::FMatrix{T}, v::AbstractVector) where {T} = Fill(-last(v), length(v)-1) + v[1:length(v)-1]
 (*)(v::Adjoint{<:Any, <:AbstractVector}, ::FMatrix) = [v -sum(v)]
 
@@ -31,7 +29,6 @@ const F = FMatrix{Int}()
 """
 struct GMatrix{T} end
 (G::GMatrix{T})(D::Integer) where {T} = -ones(T, D, D)/D + Diagonal(fill(one(T), D))
-const G = GMatrix{Float64}()
 (*)(::GMatrix, v::AbstractVector) = Fill(-sum(v)/length(v), length(v)) + v
 (*)(v::Adjoint{<:Any, <:AbstractVector}, G::GMatrix) = (G*v')'
 
@@ -42,6 +39,37 @@ const G = GMatrix{Float64}()
 """
 struct HMatrix{T} end
 (H::HMatrix{T})(d::Integer) where {T} = ones(T, d, d) + Diagonal(fill(one(T), d))
-const H = HMatrix{Int}()
 (*)(::HMatrix, v::AbstractVector) = Fill(sum(v), length(v)) + v
 (*)(v::Adjoint{<:Any, <:AbstractVector}, H::HMatrix) = (H*v')'
+
+"""
+    J(d)
+    J
+    F(d)
+    F
+    G(D)
+    G
+    H(d)
+    H
+
+User interfaces for the matrices JMatrix, FMatrix, GMatrix and HMatrix, as
+defined by Aitchison 1986.
+
+## Examples
+
+Ordinary constructors of matrices
+```
+julia> H(3)
+julia> G(3)
+```
+
+Sizeless linear transformations
+```
+julia> v'*F
+julia> G*v
+```
+"""
+const J = JMatrix{Bool}()
+const F = FMatrix{Int}()
+const G = GMatrix{Float64}()
+const H = HMatrix{Int}()

--- a/src/matrices.jl
+++ b/src/matrices.jl
@@ -19,7 +19,7 @@ struct JMatrix{T} end
 """
 struct FMatrix{T} end
 (F::FMatrix{T})(d::Integer) where {T} = [Diagonal(fill(one(T), d)) -Ones{T}(d)]
-(*)(::FMatrix{T}, v::AbstractVector) where {T} = Fill(-last(v), length(v)-1) + v[1:length(v)-1]
+(*)(::FMatrix{T}, v::AbstractVector) where {T} = Fill(-last(v), length(v)-1) + v[1:end-1]
 (*)(v::Adjoint{<:Any, <:AbstractVector}, ::FMatrix) = [v -sum(v)]
 
 """

--- a/src/matrices.jl
+++ b/src/matrices.jl
@@ -2,58 +2,52 @@
 # Licensed under the MIT License. See LICENCE in the project root.
 # ------------------------------------------------------------------
 
-import Base: *, +
-import LinearAlgebra: Diagonal
-import FillArrays: Ones
-
-abstract type AbstractElementaryMatrix{T} end
-(*)(E::AbstractElementaryMatrix, A::AbstractArray) = E(size(A)[1]) * A
-(*)(A::AbstractArray, E::AbstractElementaryMatrix) = A * E(size(A)[2])
-(+)(E::AbstractElementaryMatrix, A::AbstractArray) = E(size(A)[1]) + A
-(+)(A::AbstractArray, E::AbstractElementaryMatrix) = E + A
+abstract type CoDaMatrix{T} end
 
 """
     JMatrix{T}
 
 Square matrix of ones.
 """
-struct JMatrix{T} <: AbstractElementaryMatrix{T}
-end
+struct JMatrix{T} <: CoDaMatrix{T} end
 JMatrix{T}(d::Integer) where {T} = Ones{T}(d, d)
 (J::JMatrix{T})(d::Integer) where {T} = JMatrix{T}(d)
 const J = JMatrix{Bool}()
+(*)(::JMatrix, v::AbstractVector) = Fill(sum(v), length(v))
+(*)(v::Adjoint{<:Any, <:AbstractVector}, J::JMatrix) = (J*v')'
 
 """
     FMatrix{T}
 
 `F` matrix, as defined by Aitchison 1986.
 """
-struct FMatrix{T} <: AbstractElementaryMatrix{T}
-end
+struct FMatrix{T} <: CoDaMatrix{T} end
 FMatrix{T}(d::Integer) where {T} = [Diagonal(fill(one(T), d)) -Ones{T}(d)]
 (F::FMatrix{T})(d::Integer) where {T} = FMatrix{T}(d)
 const F = FMatrix{Int}()
-# overwrite right side multiplication, since F ins't a square matrix
-(*)(F::FMatrix, A::AbstractArray) = F(size(A)[1]-1) * A
+(*)(::FMatrix{T}, v::AbstractVector) where {T} = Fill(-last(v), length(v)-1) + v[1:length(v)-1]
+(*)(v::Adjoint{<:Any, <:AbstractVector}, ::FMatrix) = [v -sum(v)]
 
 """
     GMatrix{T}(N)
 
 `G` matrix, as defined by Aitchison 1986.
 """
-struct GMatrix{T} <: AbstractElementaryMatrix{T}
-end
+struct GMatrix{T} <: CoDaMatrix{T} end
 GMatrix{T}(D::Integer) where {T} = -ones(T, D, D)/D + Diagonal(fill(one(T), D))
 (G::GMatrix{T})(D::Integer) where {T} = GMatrix{T}(D)
 const G = GMatrix{Float64}()
+(*)(::GMatrix, v::AbstractVector) = Fill(-sum(v)/length(v), length(v)) + v
+(*)(v::Adjoint{<:Any, <:AbstractVector}, G::GMatrix) = (G*v')'
 
 """
     HMatrix{T}(d)
 
 `H` matrix, as defined by Aitchison 1986.
 """
-struct HMatrix{T} <: AbstractElementaryMatrix{T}
-end
+struct HMatrix{T} <: CoDaMatrix{T} end
 HMatrix{T}(d::Integer) where {T} = ones(T, d, d) + Diagonal(fill(one(T), d))
 (H::HMatrix{T})(d::Integer) where {T} = HMatrix{T}(d)
 const H = HMatrix{Int}()
+(*)(::HMatrix, v::AbstractVector) = Fill(sum(v), length(v)) + v
+(*)(v::Adjoint{<:Any, <:AbstractVector}, H::HMatrix) = (H*v')'

--- a/src/matrices.jl
+++ b/src/matrices.jl
@@ -2,16 +2,13 @@
 # Licensed under the MIT License. See LICENCE in the project root.
 # ------------------------------------------------------------------
 
-abstract type CoDaMatrix{T} end
-
 """
     JMatrix{T}
 
 Square matrix of ones.
 """
-struct JMatrix{T} <: CoDaMatrix{T} end
-JMatrix{T}(d::Integer) where {T} = Ones{T}(d, d)
-(J::JMatrix{T})(d::Integer) where {T} = JMatrix{T}(d)
+struct JMatrix{T} end
+(J::JMatrix{T})(d::Integer) where {T} = Ones{T}(d, d)
 const J = JMatrix{Bool}()
 (*)(::JMatrix, v::AbstractVector) = Fill(sum(v), length(v))
 (*)(v::Adjoint{<:Any, <:AbstractVector}, J::JMatrix) = (J*v')'
@@ -21,9 +18,8 @@ const J = JMatrix{Bool}()
 
 `F` matrix, as defined by Aitchison 1986.
 """
-struct FMatrix{T} <: CoDaMatrix{T} end
-FMatrix{T}(d::Integer) where {T} = [Diagonal(fill(one(T), d)) -Ones{T}(d)]
-(F::FMatrix{T})(d::Integer) where {T} = FMatrix{T}(d)
+struct FMatrix{T} end
+(F::FMatrix{T})(d::Integer) where {T} = [Diagonal(fill(one(T), d)) -Ones{T}(d)]
 const F = FMatrix{Int}()
 (*)(::FMatrix{T}, v::AbstractVector) where {T} = Fill(-last(v), length(v)-1) + v[1:length(v)-1]
 (*)(v::Adjoint{<:Any, <:AbstractVector}, ::FMatrix) = [v -sum(v)]
@@ -33,9 +29,8 @@ const F = FMatrix{Int}()
 
 `G` matrix, as defined by Aitchison 1986.
 """
-struct GMatrix{T} <: CoDaMatrix{T} end
-GMatrix{T}(D::Integer) where {T} = -ones(T, D, D)/D + Diagonal(fill(one(T), D))
-(G::GMatrix{T})(D::Integer) where {T} = GMatrix{T}(D)
+struct GMatrix{T} end
+(G::GMatrix{T})(D::Integer) where {T} = -ones(T, D, D)/D + Diagonal(fill(one(T), D))
 const G = GMatrix{Float64}()
 (*)(::GMatrix, v::AbstractVector) = Fill(-sum(v)/length(v), length(v)) + v
 (*)(v::Adjoint{<:Any, <:AbstractVector}, G::GMatrix) = (G*v')'
@@ -45,9 +40,8 @@ const G = GMatrix{Float64}()
 
 `H` matrix, as defined by Aitchison 1986.
 """
-struct HMatrix{T} <: CoDaMatrix{T} end
-HMatrix{T}(d::Integer) where {T} = ones(T, d, d) + Diagonal(fill(one(T), d))
-(H::HMatrix{T})(d::Integer) where {T} = HMatrix{T}(d)
+struct HMatrix{T} end
+(H::HMatrix{T})(d::Integer) where {T} = ones(T, d, d) + Diagonal(fill(one(T), d))
 const H = HMatrix{Int}()
 (*)(::HMatrix, v::AbstractVector) = Fill(sum(v), length(v)) + v
 (*)(v::Adjoint{<:Any, <:AbstractVector}, H::HMatrix) = (H*v')'

--- a/src/matrices.jl
+++ b/src/matrices.jl
@@ -1,0 +1,59 @@
+# ------------------------------------------------------------------
+# Licensed under the MIT License. See LICENCE in the project root.
+# ------------------------------------------------------------------
+
+import Base: *, +
+import LinearAlgebra: Diagonal
+import FillArrays: Ones
+
+abstract type AbstractElementaryMatrix{T} end
+(*)(E::AbstractElementaryMatrix, A::AbstractArray) = E(size(A)[1]) * A
+(*)(A::AbstractArray, E::AbstractElementaryMatrix) = A * E(size(A)[2])
+(+)(E::AbstractElementaryMatrix, A::AbstractArray) = E(size(A)[1]) + A
+(+)(A::AbstractArray, E::AbstractElementaryMatrix) = E + A
+
+"""
+    JMatrix{T}
+
+Square matrix of ones.
+"""
+struct JMatrix{T} <: AbstractElementaryMatrix{T}
+end
+JMatrix{T}(d::Integer) where {T} = Ones{T}(d, d)
+(J::JMatrix{T})(d::Integer) where {T} = JMatrix{T}(d)
+const J = JMatrix{Bool}()
+
+"""
+    FMatrix{T}
+
+`F` matrix, as defined by Aitchison 1986.
+"""
+struct FMatrix{T} <: AbstractElementaryMatrix{T}
+end
+FMatrix{T}(d::Integer) where {T} = [Diagonal(fill(one(T), d)) -Ones{T}(d)]
+(F::FMatrix{T})(d::Integer) where {T} = FMatrix{T}(d)
+const F = FMatrix{Int}()
+# overwrite right side multiplication, since F ins't a square matrix
+(*)(F::FMatrix, A::AbstractArray) = F(size(A)[1]-1) * A
+
+"""
+    GMatrix{T}(N)
+
+`G` matrix, as defined by Aitchison 1986.
+"""
+struct GMatrix{T} <: AbstractElementaryMatrix{T}
+end
+GMatrix{T}(D::Integer) where {T} = -ones(T, D, D)/D + Diagonal(fill(one(T), D))
+(G::GMatrix{T})(D::Integer) where {T} = GMatrix{T}(D)
+const G = GMatrix{Float64}()
+
+"""
+    HMatrix{T}(d)
+
+`H` matrix, as defined by Aitchison 1986.
+"""
+struct HMatrix{T} <: AbstractElementaryMatrix{T}
+end
+HMatrix{T}(d::Integer) where {T} = ones(T, d, d) + Diagonal(fill(one(T), d))
+(H::HMatrix{T})(d::Integer) where {T} = HMatrix{T}(d)
+const H = HMatrix{Int}()

--- a/src/matrices.jl
+++ b/src/matrices.jl
@@ -9,8 +9,8 @@ Square matrix of ones.
 """
 struct JMatrix{T} end
 (J::JMatrix{T})(d::Integer) where {T} = Ones{T}(d, d)
-(*)(::JMatrix, v::AbstractVector) = Fill(sum(v), length(v))
-(*)(v::Adjoint{<:Any, <:AbstractVector}, J::JMatrix) = (J*v')'
+*(::JMatrix, v::AbstractVector) = Fill(sum(v), length(v))
+*(v::Adjoint{<:Any, <:AbstractVector}, J::JMatrix) = (J*v')'
 
 """
     FMatrix{T}
@@ -19,8 +19,8 @@ struct JMatrix{T} end
 """
 struct FMatrix{T} end
 (F::FMatrix{T})(d::Integer) where {T} = [Diagonal(fill(one(T), d)) -Ones{T}(d)]
-(*)(::FMatrix{T}, v::AbstractVector) where {T} = Fill(-last(v), length(v)-1) + v[1:end-1]
-(*)(v::Adjoint{<:Any, <:AbstractVector}, ::FMatrix) = [v -sum(v)]
+*(::FMatrix{T}, v::AbstractVector) where {T} = Fill(-last(v), length(v)-1) + v[1:end-1]
+*(v::Adjoint{<:Any, <:AbstractVector}, ::FMatrix) = [v -sum(v)]
 
 """
     GMatrix{T}(N)
@@ -29,8 +29,8 @@ struct FMatrix{T} end
 """
 struct GMatrix{T} end
 (G::GMatrix{T})(D::Integer) where {T} = -ones(T, D, D)/D + Diagonal(fill(one(T), D))
-(*)(::GMatrix, v::AbstractVector) = Fill(-sum(v)/length(v), length(v)) + v
-(*)(v::Adjoint{<:Any, <:AbstractVector}, G::GMatrix) = (G*v')'
+*(::GMatrix, v::AbstractVector) = Fill(-sum(v)/length(v), length(v)) + v
+*(v::Adjoint{<:Any, <:AbstractVector}, G::GMatrix) = (G*v')'
 
 """
     HMatrix{T}(d)
@@ -39,37 +39,70 @@ struct GMatrix{T} end
 """
 struct HMatrix{T} end
 (H::HMatrix{T})(d::Integer) where {T} = ones(T, d, d) + Diagonal(fill(one(T), d))
-(*)(::HMatrix, v::AbstractVector) = Fill(sum(v), length(v)) + v
-(*)(v::Adjoint{<:Any, <:AbstractVector}, H::HMatrix) = (H*v')'
+*(::HMatrix, v::AbstractVector) = Fill(sum(v), length(v)) + v
+*(v::Adjoint{<:Any, <:AbstractVector}, H::HMatrix) = (H*v')'
 
 """
-    J(d)
     J
-    F(d)
-    F
-    G(D)
-    G
-    H(d)
-    H
+    J(d)
 
-User interfaces for the matrices JMatrix, FMatrix, GMatrix and HMatrix, as
-defined by Aitchison 1986.
+User interface for JMatrix, the matrix of ones.
 
 ## Examples
 
-Ordinary constructors of matrices
 ```
-julia> H(3)
-julia> G(3)
-```
-
-Sizeless linear transformations
-```
-julia> v'*F
-julia> G*v
+julia> J(3)
+julia> J*v
+julia> v'*J
 ```
 """
 const J = JMatrix{Bool}()
+
+"""
+    F
+    F(d)
+
+User interface for FMatrix, as defined by Aitchison.
+
+## Examples
+
+```
+julia> F(3)
+julia> F*v
+julia> v'*F
+```
+"""
 const F = FMatrix{Int}()
+
+
+"""
+    G
+    G(d)
+
+User interface for GMatrix, as defined by Aitchison.
+
+## Examples
+
+```
+julia> G(3)
+julia> G*v
+julia> v'*G
+```
+"""
 const G = GMatrix{Float64}()
+
+"""
+    H
+    H(d)
+
+User interface for HMatrix, as defined by Aitchison.
+
+## Examples
+
+```
+julia> H(3)
+julia> H*v
+julia> v'*H
+```
+"""
 const H = HMatrix{Int}()

--- a/src/matrices.jl
+++ b/src/matrices.jl
@@ -29,7 +29,7 @@ struct FMatrix{T} end
 """
 struct GMatrix{T} end
 (G::GMatrix{T})(D::Integer) where {T} =  I(D) - (1/D) * J(D)
-*(::GMatrix, v::AbstractVector) = v .-sum(v)/length(v)
+*(::GMatrix, v::AbstractVector) = v .- sum(v) / length(v)
 *(v::Adjoint{<:Any, <:AbstractVector}, G::GMatrix) = (G*v')'
 
 """

--- a/test/matrices.jl
+++ b/test/matrices.jl
@@ -3,14 +3,14 @@
   d = 10
   D = d+1
   @test J(d) == ones(d, d)
-  @test F(d) == [I(d) -ones(d)]
-  @test norm(G(D) - I(D)  + J(D)/ D, Inf) < 1e-5
+  @test F(d) == [I(d) - ones(d)]
+  @test G(D) ≈ I(D) - J(D)/ D
   @test H(d) == I(d) + J(d)
 
   # tests of multiplications
   for M in [J G H]
-    @test norm(M * [1:d...] - M(d) * [1:d...], Inf) < 1e-5
-    @test norm([1:d...]' * M - [1:d...]' * M(d), Inf) < 1e-5
+    @test M * [1:d...] ≈ M(d) * [1:d...]
+    @test [1:d...]' * M ≈ [1:d...]' * M(d)
   end
 
   # tests of F (d x D)

--- a/test/matrices.jl
+++ b/test/matrices.jl
@@ -16,6 +16,6 @@
   end
 
   # tests of F (d x D)
-  @test F(d) * collect(1:D) ==  F * collect(1:D)
-  @test collect(1:d)' * F(d) ==  collect(1:d)' * F
+  @test F * [1:D...] == F(d) * [1:D...]
+  @test [1:d...]' * F == [1:d...]' * F(d)
 end

--- a/test/matrices.jl
+++ b/test/matrices.jl
@@ -11,27 +11,11 @@
 
   # tests of multiplications
   for M in square_matrices
-    @test M(d) == M * I(d)
-    @test M(d) == I(d) * M
-    @test M(d) * collect(1:d) ==  M * collect(1:d)
-    @test collect(1:d)' * M(d) ==  collect(1:d)' * M
-  end
-
-  # tests of additions
-  for M in square_matrices
-    @test M(d) + M(d) == M + M(d)
-    @test M(d) + M(d) == M(d) + M
-    @test M(d) + I(d) == M + I(d)
-    @test I(d) + M(d) == I(d) + M
+    @test norm(M(d) * collect(1:d) -  M * collect(1:d), Inf) < 1e-5
+    @test norm(collect(1:d)' * M(d) - collect(1:d)' * M, Inf) < 1e-5
   end
 
   # tests of F (d x D)
-  @test F(d) == F * I(D)
-  @test F(d) == I(d) * F
   @test F(d) * collect(1:D) ==  F * collect(1:D)
   @test collect(1:d)' * F(d) ==  collect(1:d)' * F
-  @test F(d) + F(d) == F + F(d)
-  @test F(d) + F(d) == F(d) + F
-  @test F(d) + [I(d) ones(Int,d)] == F + [I(d) ones(Int,d)]
-  @test [I(d) ones(Int,d)] + F(d) == [I(d) ones(Int,d)] + F
 end

--- a/test/matrices.jl
+++ b/test/matrices.jl
@@ -11,8 +11,8 @@
 
   # tests of multiplications
   for M in square_matrices
-    @test norm(M(d) * collect(1:d) -  M * collect(1:d), Inf) < 1e-5
-    @test norm(collect(1:d)' * M(d) - collect(1:d)' * M, Inf) < 1e-5
+    @test norm(M * [1:d...] - M(d) * [1:d...], Inf) < 1e-5
+    @test norm([1:d...]' * M - [1:d...]' * M(d), Inf) < 1e-5
   end
 
   # tests of F (d x D)

--- a/test/matrices.jl
+++ b/test/matrices.jl
@@ -3,7 +3,7 @@
   d = 10
   D = d+1
   @test J(d) == ones(d, d)
-  @test F(d) == [I(d) - ones(d)]
+  @test F(d) == [I(d) -ones(d)]
   @test G(D) ≈ I(D) - J(D)/ D
   @test H(d) == I(d) + J(d)
 

--- a/test/matrices.jl
+++ b/test/matrices.jl
@@ -7,10 +7,8 @@
   @test norm(G(D) - I(D)  + J(D)/ D, Inf) < 1e-5
   @test H(d) == I(d) + J(d)
 
-  square_matrices = [J G H]
-
   # tests of multiplications
-  for M in square_matrices
+  for M in [J G H]
     @test norm(M * [1:d...] - M(d) * [1:d...], Inf) < 1e-5
     @test norm([1:d...]' * M - [1:d...]' * M(d), Inf) < 1e-5
   end

--- a/test/matrices.jl
+++ b/test/matrices.jl
@@ -1,0 +1,37 @@
+@testset "Matrices" begin
+  # tests with Aitchson's definitions
+  d = 10
+  D = d+1
+  @test J(d) == ones(d, d)
+  @test F(d) == [I(d) -ones(d)]
+  @test norm(G(D) - I(D)  + J(D)/ D, Inf) < 1e-5
+  @test H(d) == I(d) + J(d)
+
+  square_matrices = [J G H]
+
+  # tests of multiplications
+  for M in square_matrices
+    @test M(d) == M * I(d)
+    @test M(d) == I(d) * M
+    @test M(d) * collect(1:d) ==  M * collect(1:d)
+    @test collect(1:d)' * M(d) ==  collect(1:d)' * M
+  end
+
+  # tests of additions
+  for M in square_matrices
+    @test M(d) + M(d) == M + M(d)
+    @test M(d) + M(d) == M(d) + M
+    @test M(d) + I(d) == M + I(d)
+    @test I(d) + M(d) == I(d) + M
+  end
+
+  # tests of F (d x D)
+  @test F(d) == F * I(D)
+  @test F(d) == I(d) * F
+  @test F(d) * collect(1:D) ==  F * collect(1:D)
+  @test collect(1:d)' * F(d) ==  collect(1:d)' * F
+  @test F(d) + F(d) == F + F(d)
+  @test F(d) + F(d) == F(d) + F
+  @test F(d) + [I(d) ones(Int,d)] == F + [I(d) ones(Int,d)]
+  @test [I(d) ones(Int,d)] + F(d) == [I(d) ones(Int,d)] + F
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,6 +3,7 @@ using DataDeps
 using RData
 using CSV
 using Test
+using LinearAlgebra
 
 # accept downloads without interaction
 ENV["DATADEPS_ALWAYS_ACCEPT"] = true
@@ -26,6 +27,7 @@ CSV.write(joinpath(datadir,"jura.csv"), jura)
 # list of tests
 testfiles = [
   "compositions.jl",
+  "matrices.jl",
   "transforms.jl",
   "utils.jl"
 ]


### PR DESCRIPTION
As defined by Aitchison 1986.

Notes about this new PR:

A single abstract class was used to define the multiplications and additions: `AbstractElementaryMatrix`. This choice shrunk the code significantly.

Note that the ring operations only work when one of the members are subtypes of `AbstractArray`, ie, that have size.

Multiplication by scalar isn't yet implemented. This isn't a hard task, but we would probably need to think about new names to represent the structures.

With the exception of `F`, the matrices are symmetric => commutative multiplications => we could represent the composition of ring operations reasonably efficiently. But this is probably too much code for little in return.