### PR TITLE
Refactor the `Composition` type constructors

### DIFF
--- a/src/codaarrays.jl
+++ b/src/codaarrays.jl
@@ -19,7 +19,8 @@ end
 
 Base.size(array::CoDaArray) = (size(getfield(array, :data), 2),)
 
-Base.getindex(array::CoDaArray{D,PARTS}, ind::Int) where {D,PARTS} = Composition(PARTS, getfield(array, :data)[:, ind])
+Base.getindex(array::CoDaArray{D,PARTS}, ind::Int) where {D,PARTS} =
+  Composition{D,PARTS}(view(getfield(array, :data), :, ind))
 
 Base.IndexStyle(::Type{<:CoDaArray}) = IndexLinear()
 

--- a/src/compositions.jl
+++ b/src/compositions.jl
@@ -33,15 +33,21 @@ struct Composition{D,PARTS}
   data::NamedTuple{PARTS,NTuple{D,Union{Float64,Missing}}}
 end
 
-Composition(data::NamedTuple) = Composition{length(data),keys(data)}(data)
+Composition{D,PARTS}(comps::Tuple) where {D,PARTS} = Composition{D,PARTS}(NamedTuple{PARTS}(comps))
 
-Composition(; data...) = Composition((; data...))
+Composition{D,PARTS}(comps::AbstractVector) where {D,PARTS} = Composition{D,PARTS}(ntuple(i -> comps[i], D))
 
-Composition(parts::NTuple, comps) = Composition((; zip(parts, Tuple(comps))...))
+Composition(data::NamedTuple{PARTS}) where {PARTS} = Composition{length(data),PARTS}(data)
+
+Composition(; data...) = Composition(values(data))
+
+Composition(parts::NTuple{D,Symbol}, comps::Tuple) where {D} = Composition{D,parts}(comps)
+
+Composition(parts::NTuple{D,Symbol}, comps) where {D} = Composition{D,parts}(ntuple(i -> comps[i], D))
 
 Composition(comps) = Composition(ntuple(i -> Symbol(:w, i), length(comps)), comps)
 
-Composition(comp::Real, comps...) = Composition((comp, comps...))
+Composition(comps::Union{Real,Missing}...) = Composition(comps)
 
 """
     parts(c)
@@ -146,4 +152,4 @@ end
 # IO METHODS
 # -----------
 
-Base.show(io::IO, c::Composition) = join(io, (@sprintf("%.03f", w) for w in components(c)), " : ")
+Base.show(io::IO, c::Composition) = join(io, (ismissing(w) ? "missing" : @sprintf("%.03f", w) for w in components(c)), " : ")

--- a/test/codaarrays.jl
+++ b/test/codaarrays.jl
@@ -33,4 +33,11 @@
   table = compose(jura, (:Cd, :Cu, :Pb, :Co, :Cr, :Ni, :Zn), as=:comps)
   @test Tables.columnnames(table) == [:X, :Y, :Rock, :Land, :comps]
   @test Tables.getcolumn(table, :comps) == array
+
+  # performance test
+  rng = MersenneTwister(2)
+  N = 100_000
+  inds = shuffle(rng, 1:N)
+  array = CoDaArray((a=rand(rng, N), b=rand(rng, N), c=rand(rng, N)))
+  @test @elapsed(array[inds]) < 0.1
 end


### PR DESCRIPTION
master:
```
julia> Random.seed!(2);

julia> inds = shuffle(1:100_000);

julia> coda = CoDaArray((a = rand(100_000), b = rand(100_000), c = rand(100_000)));

julia> @btime coda[inds];
  5.380 s (4299492 allocations: 161.74 MiB)
```
This PR:
```
julia> Random.seed!(2);

julia> inds = shuffle(1:100_000);

julia> coda = CoDaArray((a = rand(100_000), b = rand(100_000), c = rand(100_000)));

julia> @btime coda[inds];
  18.994 ms (500002 allocations: 18.31 MiB)
```